### PR TITLE
Backport "Implement polyphonic key pressure (aftertouch) handling"

### DIFF
--- a/include/fluidsynth/synth.h
+++ b/include/fluidsynth/synth.h
@@ -110,6 +110,7 @@ FLUIDSYNTH_API int fluid_synth_get_pitch_wheel_sens(fluid_synth_t* synth, int ch
 FLUIDSYNTH_API int fluid_synth_program_change(fluid_synth_t* synth, int chan, int program);
 
 FLUIDSYNTH_API int fluid_synth_channel_pressure(fluid_synth_t* synth, int chan, int val);
+FLUIDSYNTH_API int fluid_synth_key_pressure(fluid_synth_t* synth, int chan, int key, int val);
 FLUIDSYNTH_API int fluid_synth_sysex(fluid_synth_t *synth, const char *data, int len,
                                      char *response, int *response_len, int *handled, int dryrun);
 

--- a/src/fluid_chan.c
+++ b/src/fluid_chan.c
@@ -74,7 +74,6 @@ fluid_channel_init_ctrl(fluid_channel_t* chan, int is_all_ctrl_off)
 {
   int i;
 
-  chan->key_pressure = 0;
   chan->channel_pressure = 0;
   chan->pitch_bend = 0x2000; /* Range is 0x4000, pitch bend wheel starts in centered position */
 
@@ -103,6 +102,11 @@ fluid_channel_init_ctrl(fluid_channel_t* chan, int is_all_ctrl_off)
     for (i = 0; i < 128; i++) {
       SETCC(chan, i, 0);
     }
+  }
+
+  /* Reset polyphonic key pressure on all voices */
+  for (i = 0; i < 128; i++) {
+    fluid_channel_set_key_pressure(chan, i, 0);
   }
 
   /* Set RPN controllers to NULL state */

--- a/src/fluid_chan.h
+++ b/src/fluid_chan.h
@@ -36,7 +36,7 @@ struct _fluid_channel_t
   unsigned int prognum;
   fluid_preset_t* preset;
   fluid_synth_t* synth;
-  short key_pressure;
+  char key_pressure[128];
   short channel_pressure;
   short pitch_bend;
   short pitch_wheel_sensitivity;
@@ -96,6 +96,10 @@ int fluid_channel_get_num(fluid_channel_t* chan);
 void fluid_channel_set_interp_method(fluid_channel_t* chan, int new_method);
 int fluid_channel_get_interp_method(fluid_channel_t* chan);
 
+#define fluid_channel_get_key_pressure(chan, key) \
+  ((chan)->key_pressure[key])
+#define fluid_channel_set_key_pressure(chan, key, val) \
+  ((chan)->key_pressure[key] = (val))
 #define fluid_channel_set_tuning(_c, _t)        { (_c)->tuning = _t; }
 #define fluid_channel_has_tuning(_c)            ((_c)->tuning != NULL)
 #define fluid_channel_get_tuning(_c)            ((_c)->tuning)

--- a/src/fluid_mod.c
+++ b/src/fluid_mod.c
@@ -174,7 +174,7 @@ fluid_mod_get_value(fluid_mod_t* mod, fluid_channel_t* chan, fluid_voice_t* voic
 	v1 = voice->key;
 	break;
       case FLUID_MOD_KEYPRESSURE:
-	v1 = chan->key_pressure;
+	v1 = fluid_channel_get_key_pressure(chan, voice->key);
 	break;
       case FLUID_MOD_CHANNELPRESSURE:
 	v1 = chan->channel_pressure;
@@ -267,7 +267,7 @@ fluid_mod_get_value(fluid_mod_t* mod, fluid_channel_t* chan, fluid_voice_t* voic
 	v2 = voice->key;
 	break;
       case FLUID_MOD_KEYPRESSURE:
-	v2 = chan->key_pressure;
+	v2 = fluid_channel_get_key_pressure(chan, voice->key);
 	break;
       case FLUID_MOD_CHANNELPRESSURE:
 	v2 = chan->channel_pressure;

--- a/src/fluid_synth.c
+++ b/src/fluid_synth.c
@@ -1319,6 +1319,49 @@ fluid_synth_channel_pressure(fluid_synth_t* synth, int chan, int val)
 }
 
 /**
+ * Set the MIDI polyphonic key pressure controller value.
+ * @param synth FluidSynth instance
+ * @param chan MIDI channel number (0 to MIDI channel count - 1)
+ * @param key MIDI key number (0-127)
+ * @param val MIDI key pressure value (0-127)
+ * @return FLUID_OK on success, FLUID_FAILED otherwise
+ */
+int
+fluid_synth_key_pressure(fluid_synth_t* synth, int chan, int key, int val)
+{
+  int result = FLUID_OK;
+  if (key < 0 || key > 127) {
+    return FLUID_FAILED;
+  }
+  if (val < 0 || val > 127) {
+    return FLUID_FAILED;
+  }
+
+  if (synth->verbose)
+    FLUID_LOG(FLUID_INFO, "keypressure\t%d\t%d\t%d", chan, key, val);
+
+  fluid_channel_set_key_pressure (synth->channel[chan], key, val);
+
+  // fluid_synth_update_key_pressure_LOCAL
+  {
+    fluid_voice_t* voice;
+    int i;
+
+    for (i = 0; i < synth->polyphony; i++) {
+      voice = synth->voice[i];
+
+      if (voice->chan == chan && voice->key == key) {
+        result = fluid_voice_modulate(voice, 0, FLUID_MOD_KEYPRESSURE);
+        if (result != FLUID_OK)
+          break;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
  * Set the MIDI pitch bend controller value.
  * @param synth FluidSynth instance
  * @param chan MIDI channel number


### PR DESCRIPTION
I noticed that the function was missing / gave a linker error.
Backported the patch from upstream.

Though I had no chance yet to test if the patch is correct, need to find a MIDI first that uses this xD. Quite unpopular it seems.

CC @katyo (Patch applies clean)