### PR TITLE
Cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 
-include(FindPkgConfig)
-include(GNUInstallDirs)
-
 project(fluidlite)
+
+include(GNUInstallDirs)
 
 list(APPEND HEADERS
     include/fluidlite.h
@@ -57,6 +56,8 @@ if (ENABLE_SF3 AND STB_VORBIS)
 endif()
 
 if (ENABLE_SF3 AND NOT STB_VORBIS)
+	find_package(PkgConfig QUIET)
+
 	pkg_check_modules(LIBVORBIS vorbis>=1.3.5)
 	pkg_check_modules(LIBVORBISFILE vorbisfile>=1.3.5)
 	if (NOT LIBVORBIS_FOUND OR NOT LIBVORBISFILE_FOUND)
@@ -118,6 +119,7 @@ if(FLUIDLITE_BUILD_STATIC)
 	set_target_properties(${PROJECT_NAME}-static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 	set(FLUIDLITE_LIB_TARGET ${PROJECT_NAME}-static)
 	set(FLUIDLITE_INSTALL_TARGETS ${FLUIDLITE_INSTALL_TARGETS} ";fluidlite-static")
+	set_target_properties(${PROJECT_NAME}-static PROPERTIES C_STANDARD 99)
 endif()
 
 option(FLUIDLITE_BUILD_SHARED "Build shared library" TRUE)
@@ -131,6 +133,11 @@ if(FLUIDLITE_BUILD_SHARED)
 	)
 	set(FLUIDLITE_LIB_TARGET ${PROJECT_NAME})
 	set(FLUIDLITE_INSTALL_TARGETS ${FLUIDLITE_INSTALL_TARGETS} ";fluidlite")
+	set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99)
+endif()
+
+if((NOT FLUIDLITE_BUILD_SHARED) AND (NOT FLUIDLITE_BUILD_STATIC))
+	message(FATAL_ERROR "Neither dynamic nor static library build is selected.")
 endif()
 
 if(FLUIDLITE_BUILD_SHARED AND FLUIDLITE_BUILD_STATIC)
@@ -140,17 +147,21 @@ endif()
 
 if (ENABLE_SF3)
   if (STB_VORBIS)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC SF3_SUPPORT=SF3_STB_VORBIS)
-    target_compile_definitions(${PROJECT_NAME}-static PUBLIC SF3_SUPPORT=SF3_STB_VORBIS)
+    set(SF3_SUPPORT "SF3_STB_VORBIS")
   else()
-    target_compile_definitions(${PROJECT_NAME} PUBLIC SF3_SUPPORT=SF3_XIPH_VORBIS)
-    target_compile_definitions(${PROJECT_NAME}-static PUBLIC SF3_SUPPORT=SF3_XIPH_VORBIS)
+    set(SF3_SUPPORT "SF3_XIPH_VORBIS")
+  endif()
+
+  if(FLUIDLITE_BUILD_SHARED)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC SF3_SUPPORT=${SF3_SUPPORT})
+  endif()
+  if(FLUIDLITE_BUILD_STATIC)
+    target_compile_definitions(${PROJECT_NAME}-static PUBLIC SF3_SUPPORT=${SF3_SUPPORT})
   endif()
 endif()
 
 configure_file(fluidlite.pc.in ${CMAKE_BINARY_DIR}/fluidlite.pc @ONLY)
 
-set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)
 install(TARGETS ${FLUIDLITE_INSTALL_TARGETS}
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(GNUInstallDirs)
 
 list(APPEND HEADERS
     include/fluidlite.h
-    )
+)
 
 list(APPEND SCOPED_HEADERS
     include/fluidsynth/types.h
@@ -49,123 +49,123 @@ include_directories(${CMAKE_SOURCE_DIR}/src)
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
 if (ENABLE_SF3 AND STB_VORBIS)
-  list(APPEND SOURCES
-    stb/stb_vorbis.c)
+    list(APPEND SOURCES
+        stb/stb_vorbis.c)
 
-  include_directories(${CMAKE_SOURCE_DIR}/stb)
+    include_directories(${CMAKE_SOURCE_DIR}/stb)
 endif()
 
 if (ENABLE_SF3 AND NOT STB_VORBIS)
-	find_package(PkgConfig QUIET)
+    find_package(PkgConfig QUIET)
 
-	pkg_check_modules(LIBVORBIS vorbis>=1.3.5)
-	pkg_check_modules(LIBVORBISFILE vorbisfile>=1.3.5)
-	if (NOT LIBVORBIS_FOUND OR NOT LIBVORBISFILE_FOUND)
-	   list(APPEND SOURCES
-		   libvorbis-1.3.5/lib/vorbisenc.c
-		   libvorbis-1.3.5/lib/info.c
-		   libvorbis-1.3.5/lib/analysis.c
-		   libvorbis-1.3.5/lib/bitrate.c
-		   libvorbis-1.3.5/lib/block.c
-		   libvorbis-1.3.5/lib/codebook.c
-		   libvorbis-1.3.5/lib/envelope.c
-		   libvorbis-1.3.5/lib/floor0.c
-		   libvorbis-1.3.5/lib/floor1.c
-		   libvorbis-1.3.5/lib/lookup.c
-		   libvorbis-1.3.5/lib/lpc.c
-		   libvorbis-1.3.5/lib/lsp.c
-		   libvorbis-1.3.5/lib/mapping0.c
-		   libvorbis-1.3.5/lib/mdct.c
-		   libvorbis-1.3.5/lib/psy.c
-		   libvorbis-1.3.5/lib/registry.c
-		   libvorbis-1.3.5/lib/res0.c
-		   libvorbis-1.3.5/lib/sharedbook.c
-		   libvorbis-1.3.5/lib/smallft.c
-		   libvorbis-1.3.5/lib/vorbisfile.c
-		   libvorbis-1.3.5/lib/window.c
-		   libvorbis-1.3.5/lib/synthesis.c
-	   )
-	   list(APPEND LIBVORBIS_INCLUDE_DIRS
-		   ${CMAKE_SOURCE_DIR}/libvorbis-1.3.5/include
-		   ${CMAKE_SOURCE_DIR}/libvorbis-1.3.5/lib
-	   )
-	   message(WARNING "Using libvorbis shipped sources.")
-	else()
-		message(STATUS "Using pkg-config provided libvorbis")
-		set(ADDITIONAL_LIBS "${LIBVORBIS_LDFLAGS} ${LIBVORBISFILE_LDFLAGS}")
-	endif()
+    pkg_check_modules(LIBVORBIS vorbis>=1.3.5)
+    pkg_check_modules(LIBVORBISFILE vorbisfile>=1.3.5)
+    if (NOT LIBVORBIS_FOUND OR NOT LIBVORBISFILE_FOUND)
+        list(APPEND SOURCES
+            libvorbis-1.3.5/lib/vorbisenc.c
+            libvorbis-1.3.5/lib/info.c
+            libvorbis-1.3.5/lib/analysis.c
+            libvorbis-1.3.5/lib/bitrate.c
+            libvorbis-1.3.5/lib/block.c
+            libvorbis-1.3.5/lib/codebook.c
+            libvorbis-1.3.5/lib/envelope.c
+            libvorbis-1.3.5/lib/floor0.c
+            libvorbis-1.3.5/lib/floor1.c
+            libvorbis-1.3.5/lib/lookup.c
+            libvorbis-1.3.5/lib/lpc.c
+            libvorbis-1.3.5/lib/lsp.c
+            libvorbis-1.3.5/lib/mapping0.c
+            libvorbis-1.3.5/lib/mdct.c
+            libvorbis-1.3.5/lib/psy.c
+            libvorbis-1.3.5/lib/registry.c
+            libvorbis-1.3.5/lib/res0.c
+            libvorbis-1.3.5/lib/sharedbook.c
+            libvorbis-1.3.5/lib/smallft.c
+            libvorbis-1.3.5/lib/vorbisfile.c
+            libvorbis-1.3.5/lib/window.c
+            libvorbis-1.3.5/lib/synthesis.c
+        )
+        list(APPEND LIBVORBIS_INCLUDE_DIRS
+            ${CMAKE_SOURCE_DIR}/libvorbis-1.3.5/include
+            ${CMAKE_SOURCE_DIR}/libvorbis-1.3.5/lib
+        )
+        message(WARNING "Using libvorbis shipped sources.")
+    else()
+        message(STATUS "Using pkg-config provided libvorbis")
+        set(ADDITIONAL_LIBS "${LIBVORBIS_LDFLAGS} ${LIBVORBISFILE_LDFLAGS}")
+    endif()
 
-	pkg_check_modules(LIBOGG ogg>=1.3.2)
-	if (NOT LIBOGG_FOUND)
-	   list(APPEND SOURCES
-		   libogg-1.3.2/src/bitwise.c
-		   libogg-1.3.2/src/framing.c
-	   )
-	   set(LIBOGG_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/libogg-1.3.2/include)
+    pkg_check_modules(LIBOGG ogg>=1.3.2)
+    if (NOT LIBOGG_FOUND)
+        list(APPEND SOURCES
+            libogg-1.3.2/src/bitwise.c
+            libogg-1.3.2/src/framing.c
+        )
+        set(LIBOGG_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/libogg-1.3.2/include)
 
-	   message(WARNING "Using libogg shipped sources.")
-	else()
-		message(STATUS "Using pkg-config provided libogg")
-		string(CONCAT ADDITIONAL_LIBS "${ADDITIONAL_LIBS} ${LIBOGG_LDFLAGS}")
-	endif()
+        message(WARNING "Using libogg shipped sources.")
+    else()
+        message(STATUS "Using pkg-config provided libogg")
+        string(CONCAT ADDITIONAL_LIBS "${ADDITIONAL_LIBS} ${LIBOGG_LDFLAGS}")
+    endif()
 
-	include_directories(${LIBOGG_INCLUDE_DIRS})
-	include_directories(${LIBVORBIS_INCLUDE_DIRS})
+    include_directories(${LIBOGG_INCLUDE_DIRS})
+    include_directories(${LIBVORBIS_INCLUDE_DIRS})
 endif()
 
 option(FLUIDLITE_BUILD_STATIC "Build static library" TRUE)
 if(FLUIDLITE_BUILD_STATIC)
-	add_library(${PROJECT_NAME}-static STATIC ${SOURCES})
-	set_target_properties(${PROJECT_NAME}-static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
-	set(FLUIDLITE_LIB_TARGET ${PROJECT_NAME}-static)
-	set(FLUIDLITE_INSTALL_TARGETS ${FLUIDLITE_INSTALL_TARGETS} ";fluidlite-static")
-	set_target_properties(${PROJECT_NAME}-static PROPERTIES C_STANDARD 99)
+    add_library(${PROJECT_NAME}-static STATIC ${SOURCES})
+    set_target_properties(${PROJECT_NAME}-static PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+    set(FLUIDLITE_LIB_TARGET ${PROJECT_NAME}-static)
+    set(FLUIDLITE_INSTALL_TARGETS ${FLUIDLITE_INSTALL_TARGETS} ";fluidlite-static")
+    set_target_properties(${PROJECT_NAME}-static PROPERTIES C_STANDARD 99)
 endif()
 
 option(FLUIDLITE_BUILD_SHARED "Build shared library" TRUE)
 if(FLUIDLITE_BUILD_SHARED)
-	add_library(${PROJECT_NAME} SHARED ${SOURCES})
-	target_link_libraries(${PROJECT_NAME}
-		${LIBVORBIS_LIBRARIES}
-		${LIBVORBISFILE_LIBRARIES}
+    add_library(${PROJECT_NAME} SHARED ${SOURCES})
+    target_link_libraries(${PROJECT_NAME}
+        ${LIBVORBIS_LIBRARIES}
+        ${LIBVORBISFILE_LIBRARIES}
         ${LIBOGG_LIBRARIES}
         m
-	)
-	set(FLUIDLITE_LIB_TARGET ${PROJECT_NAME})
-	set(FLUIDLITE_INSTALL_TARGETS ${FLUIDLITE_INSTALL_TARGETS} ";fluidlite")
-	set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99)
+    )
+    set(FLUIDLITE_LIB_TARGET ${PROJECT_NAME})
+    set(FLUIDLITE_INSTALL_TARGETS ${FLUIDLITE_INSTALL_TARGETS} ";fluidlite")
+    set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99)
 endif()
 
 if((NOT FLUIDLITE_BUILD_SHARED) AND (NOT FLUIDLITE_BUILD_STATIC))
-	message(FATAL_ERROR "Neither dynamic nor static library build is selected.")
+    message(FATAL_ERROR "Neither dynamic nor static library build is selected.")
 endif()
 
 if(FLUIDLITE_BUILD_SHARED AND FLUIDLITE_BUILD_STATIC)
-	set_target_properties(${PROJECT_NAME} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-	set_target_properties(${PROJECT_NAME}-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+    set_target_properties(${PROJECT_NAME} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+    set_target_properties(${PROJECT_NAME}-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 endif()
 
 if (ENABLE_SF3)
-  if (STB_VORBIS)
-    set(SF3_SUPPORT "SF3_STB_VORBIS")
-  else()
-    set(SF3_SUPPORT "SF3_XIPH_VORBIS")
-  endif()
+    if (STB_VORBIS)
+        set(SF3_SUPPORT "SF3_STB_VORBIS")
+    else()
+        set(SF3_SUPPORT "SF3_XIPH_VORBIS")
+    endif()
 
-  if(FLUIDLITE_BUILD_SHARED)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC SF3_SUPPORT=${SF3_SUPPORT})
-  endif()
-  if(FLUIDLITE_BUILD_STATIC)
-    target_compile_definitions(${PROJECT_NAME}-static PUBLIC SF3_SUPPORT=${SF3_SUPPORT})
-  endif()
+    if(FLUIDLITE_BUILD_SHARED)
+        target_compile_definitions(${PROJECT_NAME} PUBLIC SF3_SUPPORT=${SF3_SUPPORT})
+    endif()
+    if(FLUIDLITE_BUILD_STATIC)
+        target_compile_definitions(${PROJECT_NAME}-static PUBLIC SF3_SUPPORT=${SF3_SUPPORT})
+    endif()
 endif()
 
 configure_file(fluidlite.pc.in ${CMAKE_BINARY_DIR}/fluidlite.pc @ONLY)
 
 install(TARGETS ${FLUIDLITE_INSTALL_TARGETS}
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES ${SCOPED_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fluidsynth)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/fluidlite.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/fluidlite.pc.in
+++ b/fluidlite.pc.in
@@ -5,6 +5,6 @@ includedir=${prefix}/include
 
 Name: fluidlite
 Description: Software SoundFont synth
-Version: 0.0.1
+Version: 1.2.1
 Libs: -L${libdir} -lfluidlite @ADDITIONAL_LIBS@
 Cflags: -I${includedir}

--- a/include/fluidsynth/version.h
+++ b/include/fluidsynth/version.h
@@ -26,10 +26,10 @@
 extern "C" {
 #endif
 
-#define FLUIDSYNTH_VERSION       "1.2.0"
+#define FLUIDSYNTH_VERSION       "1.2.1"
 #define FLUIDSYNTH_VERSION_MAJOR 1
 #define FLUIDSYNTH_VERSION_MINOR 2
-#define FLUIDSYNTH_VERSION_MICRO 0
+#define FLUIDSYNTH_VERSION_MICRO 1
 
 
 FLUIDSYNTH_API void fluid_version(int *major, int *minor, int *micro);


### PR DESCRIPTION
- Moved ``include(GNUInstallDirs)`` below ``project`` to fix a warning.
- PkgConfig is now optional (only when external libs are used), better for Windows
- Fixed errors when static is built but not shared

2nd commit is just whitespace fixes (was a mix of tab, 2 vs. 4 spaces)