### PR TITLE
Don't leave the synth in crashing state on sfload failure

### DIFF
--- a/example/src/main.c
+++ b/example/src/main.c
@@ -10,8 +10,8 @@
 #define NUM_SAMPLES (NUM_FRAMES * NUM_CHANNELS)
 
 int main(int argc, char *argv[]) {
-    if (argc < 1) {
-      printf("Usage: %s <soundfont>[ <output>]", argv[0]);
+    if (argc < 2) {
+      printf("Usage: %s <soundfont> [<output>]\n", argv[0]);
       return 1;
     }
 
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
 
     float* buffer = calloc(SAMPLE_SIZE, NUM_SAMPLES);
 
-    FILE* file = argc > 1 ? fopen(argv[2], "wb") : stdout;
+    FILE* file = argc > 2 ? fopen(argv[2], "wb") : stdout;
 
     fluid_synth_noteon(synth, 0, 60, 127);
     fluid_synth_write_float(synth, NUM_FRAMES, buffer, 0, NUM_CHANNELS, buffer, 1, NUM_CHANNELS);

--- a/src/fluid_synth.c
+++ b/src/fluid_synth.c
@@ -2574,14 +2574,12 @@ fluid_synth_sfload(fluid_synth_t* synth, const char* filename, int reset_presets
   for (list = synth->loaders; list; list = fluid_list_next(list)) {
     loader = (fluid_sfloader_t*) fluid_list_get(list);
 
-    sfont = FLUID_NEW(fluid_sfont_t);
+    sfont = fluid_sfloader_load(loader, filename);
+    if (sfont == NULL)
+        return -1;
+
     sfont->id = ++synth->sfont_id;
     synth->sfont = fluid_list_prepend(synth->sfont, sfont);
-
-    loader->data = sfont;
-    fluid_sfloader_load(loader, filename);
-    loader->data = NULL;
-
 
     if (reset_presets) {
         fluid_synth_program_reset(synth);


### PR DESCRIPTION
Hi, this fixes a FluidLite crash after a soundfont cannot load, such as when the file does not exist.
Also when the soundfont would fail loading, it would return a valid id instead of -1, making it impossible to detect the failure.

This problem was illustrated by the example program.
When passing the program a file which does not exist, a crash likely follows.

(fixed also some mistakes in the example.)