### PR TITLE
Fix incorrect playback of drums (Channel 10)

### DIFF
--- a/src/fluid_chan.c
+++ b/src/fluid_chan.c
@@ -248,6 +248,10 @@ fluid_channel_cc(fluid_channel_t* chan, int num, int value)
 
   case BANK_SELECT_MSB:
     {
+      if (chan->channum == 9 && fluid_settings_str_equal(chan->synth->settings, "synth.drums-channel.active", "yes")) {
+        return FLUID_OK; /* ignored */
+      }
+
       chan->bank_msb = (unsigned char) (value & 0x7f);
 /*      printf("** bank select msb recieved: %d\n", value); */
 
@@ -265,6 +269,9 @@ fluid_channel_cc(fluid_channel_t* chan, int num, int value)
 
   case BANK_SELECT_LSB:
     {
+      if (chan->channum == 9 && fluid_settings_str_equal(chan->synth->settings, "synth.drums-channel.active", "yes")) {
+        return FLUID_OK; /* ignored */
+      }
       /* FIXME: according to the Downloadable Sounds II specification,
          bit 31 should be set when we receive the message on channel
          10 (drum channel) */

--- a/src/fluid_synth.c
+++ b/src/fluid_synth.c
@@ -1559,7 +1559,13 @@ fluid_synth_program_change(fluid_synth_t* synth, int chan, int prognum)
   if (synth->verbose)
     FLUID_LOG(FLUID_INFO, "prog\t%d\t%d\t%d", chan, banknum, prognum);
 
-  preset = fluid_synth_find_preset(synth, banknum, prognum); //if (channel->channum == 9) fluid_synth_find_preset(synth, DRUM_INST_BANK, prognum);
+  if (channel->channum == 9 && fluid_settings_str_equal(synth->settings, "synth.drums-channel.active", "yes")) {
+    preset = fluid_synth_find_preset(synth, DRUM_INST_BANK, prognum);
+  }
+  else
+  {
+    preset = fluid_synth_find_preset(synth, banknum, prognum);
+  }
 
   /* Fallback to another preset if not found */
   if (!preset)


### PR DESCRIPTION
_We added FluidLite (Because glib sucks) support now to EasyRPG Player https://github.com/easyrpg/player - A runtime for RPG Maker 2000 games - and almost all of these games use MIDIs, so expect that we will find and fix bugs now ;). The first issue we encountered is that drums sound wrong. Besides this we have no issues by now. Good job :+1:_ 

CC @katyo

This fixes broken Drums. 
Channel 10 (in the code 9 because it starts from 0) should play drums by default but this wasn't working.

The "synth.drums-channel.active" flag is respected, when it is "off" then it sounds like before (without drums).

1st commit:

For CC I ignore now LSB and MSB on the Drum channel. This is Fluidsynth behaviour:
https://github.com/FluidSynth/fluidsynth/blob/v1.1.11/src/synth/fluid_chan.c#L232-L239
https://github.com/FluidSynth/fluidsynth/blob/v1.1.11/src/synth/fluid_chan.c#L266-L268

2nd commit:

There was commented out code here, reenabling it fixes the drums.

-------------
**Files attached**

See this file attached: fluidlite.opus is without the patch. fluidsynth.opus is with upstream fluidsynth and fluidlite sounds like this after the patch. You can hear the difference during the first seconds and close to the end.

Recording: https://github.com/EasyRPG/Player/files/5126234/midi.zip

Soundfont used: https://stash.reaper.fm/v/23360/Scc1t2.sf2

MIDI used (NOTE: The playback speed in the midi.zip is 150% because I recorded this inside of the game runtime and the tempo was changed): https://github.com/divideconcept/FluidLite/files/5123720/opening2.zip