### PR TITLE
synth.h: Fixed C90 compatibility

### DIFF
--- a/include/fluidsynth/synth.h
+++ b/include/fluidsynth/synth.h
@@ -701,10 +701,12 @@ FLUIDSYNTH_API void fluid_synth_get_voicelist(fluid_synth_t* synth,
 					    fluid_voice_t* buf[], int bufsize, int ID);
 
 
-//midi router disabled
-//  /** This is a hack to get command handlers working */
-//FLUIDSYNTH_API void fluid_synth_set_midi_router(fluid_synth_t* synth,
-//					      fluid_midi_router_t* router);
+/* midi router disabled */
+#if 0
+  /** This is a hack to get command handlers working */
+FLUIDSYNTH_API void fluid_synth_set_midi_router(fluid_synth_t* synth,
+					      fluid_midi_router_t* router);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Using C++-style single-line comments is not allowed by C89/C90 standard. That breaks the compatibility with some external programs.

Please use `/*  */` or `#if 0 ...  #endif` to make sure C90 compatibility will not be broken