### PR TITLE
Minor fixups

### DIFF
--- a/src/fluid_chorus.c
+++ b/src/fluid_chorus.c
@@ -237,7 +237,7 @@ void fluid_chorus_set_nr(fluid_chorus_t* chorus, int nr)
 int fluid_chorus_get_nr(fluid_chorus_t* chorus)
 {
     return chorus->number_blocks;
-};
+}
 
 /* Purpose:
  * Sets the mixing level of the signal from each delay line (linear).
@@ -253,7 +253,7 @@ void fluid_chorus_set_level(fluid_chorus_t* chorus, fluid_real_t level)
 fluid_real_t fluid_chorus_get_level(fluid_chorus_t* chorus)
 {
     return chorus->level;
-};
+}
 
 /* Purpose:
  * Sets the modulation frequency.
@@ -270,7 +270,7 @@ void fluid_chorus_set_speed_Hz(fluid_chorus_t* chorus, fluid_real_t speed_Hz)
 fluid_real_t fluid_chorus_get_speed_Hz(fluid_chorus_t* chorus)
 {
     return chorus->speed_Hz;
-};
+}
 
 /* Purpose:
  * Sets the modulation depth in ms.
@@ -287,7 +287,7 @@ void fluid_chorus_set_depth_ms(fluid_chorus_t* chorus, fluid_real_t depth_ms)
 fluid_real_t fluid_chorus_get_depth_ms(fluid_chorus_t* chorus)
 {
     return chorus->depth_ms;
-};
+}
 
 /* Purpose:
  * Sets the type of the modulation waveform.
@@ -304,7 +304,7 @@ void fluid_chorus_set_type(fluid_chorus_t* chorus, int type)
 int fluid_chorus_get_type(fluid_chorus_t* chorus)
 {
     return chorus->type;
-};
+}
 
 void
 delete_fluid_chorus(fluid_chorus_t* chorus)

--- a/src/fluid_defsfont.c
+++ b/src/fluid_defsfont.c
@@ -802,7 +802,7 @@ fluid_defpreset_noteon(fluid_defpreset_t* preset, fluid_synth_t* synth, int chan
 {
   fluid_preset_zone_t *preset_zone, *global_preset_zone;
   fluid_inst_t* inst;
-  fluid_inst_zone_t *inst_zone, *global_inst_zone, *z;
+  fluid_inst_zone_t *inst_zone, *global_inst_zone;
   fluid_sample_t* sample;
   fluid_voice_t* voice;
   fluid_mod_t * mod;
@@ -847,8 +847,6 @@ fluid_defpreset_noteon(fluid_defpreset_t* preset, fluid_synth_t* synth, int chan
 	    return FLUID_FAILED;
 	  }
 
-
-	  z = inst_zone;
 
 	  /* Instrument level, generators */
 

--- a/src/fluid_mod.c
+++ b/src/fluid_mod.c
@@ -354,7 +354,7 @@ fluid_mod_new()
     return NULL;
   }
   return mod;
-};
+}
 
 /*
  * fluid_mod_delete
@@ -363,7 +363,7 @@ void
 fluid_mod_delete(fluid_mod_t * mod)
 {
   FLUID_FREE(mod);
-};
+}
 
 /*
  * fluid_mod_test_identity
@@ -379,7 +379,7 @@ int fluid_mod_test_identity(fluid_mod_t * mod1, fluid_mod_t * mod2){
   if (mod1->flags1 != mod2->flags1){return 0;}
   if (mod1->flags2 != mod2->flags2){return 0;}
   return 1;
-};
+}
 
 /* debug function: Prints the contents of a modulator */
 void fluid_dump_modulator(fluid_mod_t * mod){
@@ -429,6 +429,6 @@ void fluid_dump_modulator(fluid_mod_t * mod){
       default: printf("dest %i",dest);
   }; /* switch dest */
   printf(", amount %f flags %i src2 %i flags2 %i\n",amount, flags1, src2, flags2);
-};
+}
 
 

--- a/src/fluid_ramsfont.c
+++ b/src/fluid_ramsfont.c
@@ -791,7 +791,7 @@ fluid_rampreset_noteon(fluid_rampreset_t* preset, fluid_synth_t* synth, int chan
 {
   fluid_preset_zone_t *preset_zone;
   fluid_inst_t* inst;
-  fluid_inst_zone_t *inst_zone, *global_inst_zone, *z;
+  fluid_inst_zone_t *inst_zone, *global_inst_zone;
   fluid_sample_t* sample;
   fluid_voice_t* voice;
   fluid_mod_t * mod;
@@ -838,7 +838,6 @@ fluid_rampreset_noteon(fluid_rampreset_t* preset, fluid_synth_t* synth, int chan
 	    return FLUID_FAILED;
 	  }
 
-	  z = inst_zone;
 
 	  /* Instrument level, generators */
 

--- a/src/fluid_synth.c
+++ b/src/fluid_synth.c
@@ -2527,7 +2527,7 @@ void fluid_synth_kill_by_exclusive_class(fluid_synth_t* synth, fluid_voice_t* ne
 
     fluid_voice_kill_excl(existing_voice);
   };
-};
+}
 
 /*
  * fluid_synth_start_voice
@@ -2951,7 +2951,7 @@ int fluid_synth_set_interp_method(fluid_synth_t* synth, int chan, int interp_met
     };
   };
   return FLUID_OK;
-};
+}
 
 /* Purpose:
  * Returns the number of allocated midi channels

--- a/src/fluid_synth.c
+++ b/src/fluid_synth.c
@@ -731,7 +731,7 @@ delete_fluid_synth(fluid_synth_t* synth)
 /*
  * fluid_synth_error
  *
- * The error messages are not thread-save, yet. They are still stored
+ * The error messages are not thread-safe, yet. They are still stored
  * in a global message buffer (see fluid_sys.c).
  * */
 char*


### PR DESCRIPTION
Fixed:
- some warnings
- a spelling mistake
- a bugfix (I think).

But let me know if the last commit is actually a bugfix, or if the user is supposed to do this beforehand:
```c
synth->sample_rate = sample_rate;
fluid_synth_set_sample_rate(synth, &sample_rate);
```