### PR TITLE
Better handling dependencies for end users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,12 +74,12 @@ list(APPEND SOURCES
 
 if (ENABLE_SF3)
     if (STB_VORBIS)
-        set(SF3_SUPPORT "SF3_STB_VORBIS")
+        set(FLUIDLITE_SF3_SUPPORT "SF3_STB_VORBIS")
     else()
-        set(SF3_SUPPORT "SF3_XIPH_VORBIS")
+        set(FLUIDLITE_SF3_SUPPORT "SF3_XIPH_VORBIS")
     endif()
 else()
-    set(SF3_SUPPORT "SF3_DISABLED")
+    set(FLUIDLITE_SF3_SUPPORT "SF3_DISABLED")
 endif()
 
 configure_file(src/fluid_config.cmake ${PROJECT_BINARY_DIR}/fluid_config.h @ONLY)
@@ -111,10 +111,13 @@ if (UNIX AND NOT APPLE)
     endif()
 endif()
 
+set(FLUIDLITE_VENDORED FALSE)
 if (ENABLE_SF3 AND NOT STB_VORBIS)
     find_package(Vorbis QUIET)
     if (NOT TARGET Vorbis::vorbisfile)
         message(WARNING "Using vendored libogg/libvorbis")
+
+        set(FLUIDLITE_VENDORED TRUE)
 
         list(APPEND SOURCES
             libogg-1.3.2/src/bitwise.c
@@ -157,6 +160,8 @@ endif()
 
 if (ENABLE_SF3 AND STB_VORBIS)
     message(STATUS "Using vendored stb_vorbis")
+
+    set(FLUIDLITE_VENDORED TRUE)
 
     list(APPEND SOURCES stb/stb_vorbis.c)
     target_include_directories(${PROJECT_NAME}-options INTERFACE ${PROJECT_SOURCE_DIR}/stb)
@@ -230,6 +235,15 @@ configure_file(fluidlite.pc.in ${PROJECT_BINARY_DIR}/fluidlite.pc @ONLY)
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES ${SCOPED_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fluidlite)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/fluidlite.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+if(FLUIDLITE_BUILD_STATIC AND NOT FLUIDLITE_VENDORED)
+    install(
+        FILES
+            cmake/FindOgg.cmake
+            cmake/FindVorbis.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    )
+endif()
 
 # Exported targets
 

--- a/fluidlite-config.cmake.in
+++ b/fluidlite-config.cmake.in
@@ -1,6 +1,12 @@
 @PACKAGE_INIT@
 
-set(SF3_SUPPORT @SF3_SUPPORT@)
+set(FLUIDLITE_SF3_SUPPORT  @FLUIDLITE_SF3_SUPPORT@)
+set(FLUIDLITE_VENDORED     @FLUIDLITE_VENDORED@)
+
+if(NOT FLUIDLITE_VENDORED)
+    set(_fluidlite_cmake_module_path "${CMAKE_MODULE_PATH}")
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+endif()
 
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-shared-targets.cmake")
    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-shared-targets.cmake")
@@ -8,9 +14,14 @@ endif()
 
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-static-targets.cmake")
    include(CMakeFindDependencyMacro)
-   if("${SF3_SUPPORT}" STREQUAL "SF3_XIPH_VORBIS" AND NOT TARGET Vorbis::vorbisfile)
-      find_dependency(Vorbis REQUIRED)
+   if("${FLUIDLITE_SF3_SUPPORT}" STREQUAL "SF3_XIPH_VORBIS" AND NOT FLUIDLITE_VENDORED AND NOT TARGET Vorbis::vorbisfile)
+      find_dependency(Vorbis)
    endif()
 
    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-static-targets.cmake")
+endif()
+
+if(NOT FLUIDLITE_VENDORED)
+    set(CMAKE_MODULE_PATH "${_fluidlite_cmake_module_path}")
+    unset(_fluidlite_cmake_module_path)
 endif()

--- a/src/fluid_config.cmake
+++ b/src/fluid_config.cmake
@@ -14,7 +14,7 @@
 #define SF3_DISABLED 0
 #define SF3_XIPH_VORBIS 1
 #define SF3_STB_VORBIS 2
-#define SF3_SUPPORT @SF3_SUPPORT@
+#define SF3_SUPPORT @FLUIDLITE_SF3_SUPPORT@
 
 /* if defined, the synth uses float (32 bit) samples, otherwise it uses double (64 bit) samples */
 #cmakedefine WITH_FLOAT


### PR DESCRIPTION
1) Copy CMake find modules to install prefix
2) Find dependency only if it wasn't vendored