### PR TITLE
minor clean-up to libvorbis support

### DIFF
--- a/src/fluid_defsfont.c
+++ b/src/fluid_defsfont.c
@@ -28,8 +28,7 @@
 #include "fluid_sys.h"
 
 #if SF3_SUPPORT == SF3_XIPH_VORBIS
-#include "vorbis/codec.h"
-#include "vorbis/vorbisenc.h"
+#define OV_EXCLUDE_STATIC_CALLBACKS
 #include "vorbis/vorbisfile.h"
 
 struct VorbisData {


### PR DESCRIPTION
- define `OV_EXCLUDE_STATIC_CALLBACKS` to avoid warnings,
- remove unnecessary `codec.h` and `vorbisenc.h` includes.

CC @mmontag 
